### PR TITLE
update vrna header for SHAPE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
     - export CONDA_PATH=$HOME/miniconda3
     - export PATH=$CONDA_PATH/bin:$PATH
     - conda update --yes conda
-    - conda install --yes gcc automake pkgconfig viennarna boost=1.61.* -c conda-forge -c bioconda
+    - conda install --yes gcc automake pkgconfig viennarna>=2.4.8 boost=1.61.* -c conda-forge -c bioconda
     - export CONDA_LIB_PATH=$CONDA_PATH/lib
     #    - ls $CONDA_LIB_PATH
     #    - ls $CONDA_PATH/include

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ dependencies:
     - libboost_program_options
     - libboost_filesystem
     - libboost_system
-- [Vienna RNA package](http://www.tbi.univie.ac.at/RNA/) version >= 2.4.4
+- [Vienna RNA package](http://www.tbi.univie.ac.at/RNA/) version >= 2.4.8
 - if [cloning from github](#instgithub): GNU autotools (automake, autoconf, ..)
 
 Also used by IntaRNA, but already part of the source code distribution (and thus

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_INIT([IntaRNA], [2.2.0], [], [intaRNA], [http://www.bioinf.uni-freiburg.de] )
 # minimal required version of the boost library 
 BOOST_REQUIRED_VERSION=1.50.0
 # minimal required version of the Vienna RNA library
-VRNA_REQUIRED_VERSION=2.4.4
+VRNA_REQUIRED_VERSION=2.4.8
 
 
 AC_CANONICAL_HOST

--- a/src/IntaRNA/AccessibilityVrna.cpp
+++ b/src/IntaRNA/AccessibilityVrna.cpp
@@ -12,6 +12,7 @@ extern "C" {
 	#include <ViennaRNA/part_func.h>
 	#include <ViennaRNA/fold.h>
 	#include <ViennaRNA/model.h>
+	#include <ViennaRNA/constraints/SHAPE.h>
 }
 
 // RNAup-like ED filling


### PR DESCRIPTION
Vienna RNA headers directory structure has changed in version 2.4.8. This small PR fixes compilation error of linking new vrna-lib with IntaRNA.